### PR TITLE
feat: Add --sample-schema flag and bump version to 0.2.0 for PyPI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ redcap-eda analyze --sample
 
 ### 🔹 Example Using the Sample Dataset with a Predefined Schema
 ```bash
-redcap-eda analyze --sample --schema schemas/schema_sample_dataset.json
+redcap-eda analyze --sample --sample-schema
 ```
 
 ### 🔹 Running EDA on a Custom Dataset with Interactive Schema Creation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "redcap-eda"
-version = "0.1.0"
+version = "0.2.0"
 description = "Perform exploratory data analysis on REDCap data"
 authors = [
     {name = "Robert Portelli"}

--- a/src/redcap_eda/cast_schema.py
+++ b/src/redcap_eda/cast_schema.py
@@ -36,6 +36,40 @@ class SchemaHandler:
         "object": "Mixed data types, unstructured text, or complex objects.",
     }
 
+    SAMPLE_SCHEMA = {
+        "record_id": "int64",
+        "unvalidated_text": "string",
+        "date_dmy": "datetime64[ns]",
+        "date_mdy": "datetime64[ns]",
+        "date_ymd": "datetime64[ns]",
+        "datetime_dmyhm": "datetime64[ns]",
+        "datetime_mdyhm": "datetime64[ns]",
+        "datetime_ymdhm": "datetime64[ns]",
+        "datetime_dmyhms": "datetime64[ns]",
+        "datetime_mdyhms": "datetime64[ns]",
+        "datetime_ymdhms": "datetime64[ns]",
+        "email": "string",
+        "integer": "int64",
+        "number": "float64",
+        "phone": "string",
+        "time": "datetime64[ns]",
+        "zip": "int64",
+        "notes": "string",
+        "calculated": "float64",
+        "dropdown_numeric": "int64",
+        "dropdown_character": "category",
+        "dropdown_mixed": "category",
+        "radio_buttons": "int64",
+        "checkbox___1": "category",
+        "checkbox___2": "category",
+        "checkbox___3": "category",
+        "yes_no": "bool",
+        "true_false": "bool",
+        "signature_draw": "object",
+        "file_upload": "object",
+        "slider": "int64",
+    }
+
     def __init__(self, schema_path: str | None = None):
         """
         Initializes SchemaHandler.
@@ -211,6 +245,10 @@ class SchemaHandler:
         Returns:
             str: The schema file path.
         """
+        if self.schema_path == "sample":
+            logger.info("📥 Using built-in SAMPLE_SCHEMA")
+            self.schema = self.SAMPLE_SCHEMA
+            return self.schema_path
         if self.schema_path and os.path.exists(self.schema_path):
             logger.info(f"📥 Loading schema from {self.schema_path}")
             self.load_schema()


### PR DESCRIPTION
## Description
This pull request introduces a new feature to the REDCap-EDA project by adding the `--sample-schema` flag to the `analyze` CLI command. This flag allows users to apply a predefined sample schema (`SAMPLE_SCHEMA`) to the sample dataset without needing an external schema file. This resolves #8

Additionally, the project version has been bumped to `0.2.0` in the `pyproject.toml` file to support the upcoming PyPI release.

## Changes Made
- Added `SAMPLE_SCHEMA` as a class constant in `SchemaHandler`.
- Implemented logic to apply `SAMPLE_SCHEMA` when `--sample-schema` is used.
- Updated the CLI to include the `--sample-schema` flag.
- Improved error handling for conflicting CLI options.
- Bumped the project version to `0.2.0` in `pyproject.toml`.

## How to Test
1. Run `poetry install` to update dependencies.
2. Use the `analyze` command with the `--sample-schema` flag:
```sh
redcap-eda analyze --sample --sample-schema
```
3. Validate that `SAMPLE_SCHEMA` is applied and reflected in the generated EDA report.

## Checklist
- [x] All existing and new unit tests pass.
- [x] Version bumped to `0.2.0`.
- [x] PyPI package is ready for release.

## Additional Notes
This feature is fully backward-compatible and does not affect existing workflows. The version bump ensures that the new feature is available to all users via PyPI.

- **feat: Add support for --sample-schema flag and integrate SAMPLE_SCHEMA**
- **update readme**
- **version bump**
